### PR TITLE
사이드 바에서 "카테고리 없음" 제거

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -297,8 +297,6 @@ defaults:
       comments: true
       share: false
       related: true
-      categories:
-        - "Uncategorized"
 
 # 한국이 GMT +0900이라,
 # 가끔 미래의 포스트로 취급되어 렌더링이 되지 않는 포스트가 생김.

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -26,5 +26,3 @@ categories:
         url: /categories/#macos
       - title: "Web Browser"
         url: /categories/#web-browser
-      - title: "카테고리 없음"
-        url: /categories/#uncategorized


### PR DESCRIPTION
#9 에서 _config.yml 의 각 포스트의 기본 값으로 다음과 같이 설정해두었다.
```yml

# Defaults
defaults:

# ...

      related: true
      categories:
        - "Uncategorized"
```

이렇게 하면, 카테고리를 매기지 않은 포스트**만** "Uncategorized" 카테고리로 분류되어 질 줄 알았다.

그러나, 카테고리가 이미 부여된 포스트도 "Uncategorized" 카테고리로 분류됨과 동시에 기존의 카테고리를 동시에 갖게 되었다.

이로인해 기존의 포스트들의 주소가 변경되었다.


전혀 의도했던 동작이 아니므로, #9 에서 추가하려던 "Uncategorized" 카테고리를 롤백한다.