### PR TITLE
Don't use placeholder `: slugified_categories` for permalink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -217,7 +217,7 @@ sass:
 
 
 # Outputting
-permalink: /:slugified_categories/:title/
+permalink: /:categories/:title/
 paginate: 5 # amount of posts to show
 paginate_path: /page:num/
 timezone: KR # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/_posts/Musical Phantom/2021-12-07-phantom.md
+++ b/_posts/Musical Phantom/2021-12-07-phantom.md
@@ -3,7 +3,7 @@ title:  "[Musical] #1 뮤지컬 \"팬텀\" 후기"
 excerpt: "팬텀을 보고 왔습니다. (박은태, 임선혜)"
 
 categories:
-  - "Musical Phantom"
+  - "musical-phantom"
 
 tags:
   - []

--- a/_posts/Splendor/2021-12-05-splendor-prepare.md
+++ b/_posts/Splendor/2021-12-05-splendor-prepare.md
@@ -3,7 +3,7 @@ title:  "[Splendor] 사용할 기술 스택 정하기"
 excerpt: "스플렌더 프로젝트를 기획해보자."
 
 categories:
-- "Splendor"
+- "splendor"
 
 tags:
 - [Project, Splendor]

--- a/_posts/Splendor/2021-12-16-decided-reengineering.md
+++ b/_posts/Splendor/2021-12-16-decided-reengineering.md
@@ -2,7 +2,7 @@
 title:  "[Splendor] 사이드 프로젝트 : 스플렌더"
 
 categories:
-  - "Splendor"
+  - "splendor"
 
 tags:
   - "side-project"

--- a/_posts/Web Browser/2021-12-13-safari-debugging-tool.md
+++ b/_posts/Web Browser/2021-12-13-safari-debugging-tool.md
@@ -2,7 +2,7 @@
 title:  "[웹브라우저] Safari에서 개발자 도구 사용하기"
 
 categories:
-  - "Web Browser"
+  - "web-browser"
 
 tags:
   - "Web Browser"

--- a/_posts/macOS/2021-12-15-invalid-active-developer-path.md
+++ b/_posts/macOS/2021-12-15-invalid-active-developer-path.md
@@ -3,7 +3,7 @@ title:  "[macOS] OS 업데이트 후 개발도구 오류 (xcrun: error: invalid 
 excerpt: "macOS Monterey로 업데이트 하고나니 생긴 개발도구 오류를 해결해보자."
 
 categories:
-  - "macOS"
+  - "macos"
 
 tags:
   - "Xcode"


### PR DESCRIPTION
Replace :slugified_categories with :categories in _config.yml

the :slugified_categories option is not supported for jekyll under v4.1.

GitHub uses Jekyll v3.9, and the build keep fails.

https://github.com/Hepheir/hepheir.github.io/runs/4581588252?check_suite_focus=true